### PR TITLE
Githuib actions to publish to npmjs

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,31 +1,20 @@
-# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
-# For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
-
 name: Publish to npmjs.org
 
-on: workflow_dispatch
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
 
 jobs:
-    build:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v3
-            - uses: actions/setup-node@v3
-              with:
-                  node-version: 20
-            - run: npm run ci
-            - run: npm test
-
-    publish-npm:
-        needs: build
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v3
-            - uses: actions/setup-node@v3
-              with:
-                  node-version: 20
-                  registry-url: https://registry.npmjs.org/
-            - run: npm run ci
-            - run: npm publish
-              env:
-                  NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org/
+      - run: cd lib && npm install && npm run build
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ test-coverage/
 **/.VSCodeCounter/
 .VSCodeCounter/
 **/.DS_Store
+.DS_Store
+**/.DS_Store/
+.DS_Store/

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,17 +1,16 @@
-# Release Notes — v0.24.16
+# Release Notes
 
-By default `<MorphioViewerSimul />` starts in 3D mode, and can then be switched to Dendrogram mode.
-The synapses stick to the neurites when transitionning between these modes, but only if they are added in 3D mode.
-If you add synapses when in Dendrogram mode, they appear in 3D view, creating an inconstancy in the view.
+## Package rename
 
-This release fix this issue.
+The npm package has been renamed from `@bbp/morphoviewer` to `@openbraininstitute/morphoviewer`.
 
-## Bug Fixes
+## CI/CD improvements
 
-- Preserve synapses when transitioning between views (use existing view synapses instead of resetting)
-- Apply mix value to newly created synapse painters so they render correctly
+- Simplified the npm publish workflow into a single job (removed separate build/test step)
+- Upgraded GitHub Actions from v3 to v4 (`actions/checkout`, `actions/setup-node`)
+- Auto-publish on push to `main` (in addition to manual `workflow_dispatch`)
+- Publish now uses `--access public`
 
-## Refactoring
+## Misc
 
-- Convert GLSL shader files (.frag, .vert) to TypeScript modules for gizmo tips painter because it was forcing the bundler of the library client to add special rules for them.
-- Remove unused `TgdVec3` import from tips painter
+- Improved `.gitignore` to better handle `.DS_Store` files

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@bbp/morphoviewer",
+    "name": "@openbraininstitute/morphoviewer",
     "version": "0.24.16",
     "description": "Class to display SWC files in 3D on a canvas",
     "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@bbp/morphoviewer",
+    "name": "@openbraininstitute/morphoviewer",
     "version": "0.24.16",
     "description": "Class to display SWC morphology files in 3D",
     "main": "./lib/dist/index.js",


### PR DESCRIPTION
# Release Notes

## Package rename

The npm package has been renamed from `@bbp/morphoviewer` to `@openbraininstitute/morphoviewer`.

## CI/CD improvements

- Created github action __"Publish to npmjs.org"__ to publish the morpho viewer library to our npm repo.
- Simplified the npm publish workflow into a single job (removed separate build/test step)
- Upgraded GitHub Actions from v3 to v4 (`actions/checkout`, `actions/setup-node`)
- Auto-publish on push to `main` (in addition to manual `workflow_dispatch`)
- Publish now uses `--access public`

## Misc

- Improved `.gitignore` to better handle `.DS_Store` files

