### PR TITLE
Add Gizmo for small circuit

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ Copyright (c) 2025 Open Brain Institute
 
 ## Release notes
 
+### v0.24.21
+
+- Add optional `gizmo` prop to `MorphoViewerSmallCircuit` for displaying an axes orientation controller
+  - Accepts `boolean` or a `Partial<TgdPainterGizmoOptions>` object (`alignX`, `alignY`, `size`, `margin`)
+  - Dynamically updates gizmo position, size, and visibility at runtime
+- Reuse `GizmoSettings` component in the `MorphoViewerSmallCircuit` doc page for interactive gizmo configuration
+- Move `GizmoSettings` component to shared `doc/src/components/gizmo-settings/` directory
+- Remove leftover `console.log` debug statements from `OctreeManager`
+- Fix import ordering in `tst/rspack.config.mjs`
+
 ### v0.24.20
 
 - Add optional `gizmo` prop to `MorphoViewerOctree` for displaying an axes orientation controller
@@ -43,4 +53,4 @@ Copyright (c) 2025 Open Brain Institute
 
 ### v0.24.18
 
-- Add Tauri-based testing tool (`tst/`) for checking LOD blocks bounding boxes
+- Add Tauri-based testing tool (`tst/`) for checking LOD blocks bounding boxes potential misalignements

--- a/doc/package-lock.json
+++ b/doc/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "extended-swc-viewer",
-    "version": "0.24.18",
+    "version": "0.24.21",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "extended-swc-viewer",
-            "version": "0.24.18",
+            "version": "0.24.21",
             "dependencies": {
                 "@mdx-js/react": "^3.1.1",
                 "@openbraininstitute/morphoviewer": "file:../lib",
@@ -57,10 +57,10 @@
         },
         "../lib": {
             "name": "@openbraininstitute/morphoviewer",
-            "version": "0.24.18",
+            "version": "0.24.21",
             "license": "ISC",
             "dependencies": {
-                "@tolokoban/tgd": "^2.0.126",
+                "@tolokoban/tgd": "^2.0.130",
                 "fflate": "^0.8.2",
                 "tslib": "^2.8.1"
             },

--- a/doc/package.json
+++ b/doc/package.json
@@ -1,6 +1,6 @@
 {
     "name": "extended-swc-viewer",
-    "version": "0.24.20",
+    "version": "0.24.21",
     "private": false,
     "homepage": "./",
     "sideEffects": [

--- a/doc/src/app/morpho-viewer-octree/page.tsx
+++ b/doc/src/app/morpho-viewer-octree/page.tsx
@@ -3,7 +3,7 @@ import { assertType } from "@tolokoban/type-guards";
 import { ViewLabel, ViewOptions } from "@tolokoban/ui";
 import React from "react";
 
-import { GizmoSettings } from "./gizmo-settings";
+import { GizmoSettings } from "@/components/gizmo-settings";
 
 import Styles from "./page.module.css";
 

--- a/doc/src/app/morpho-viewer-small-circuit/page.module.css
+++ b/doc/src/app/morpho-viewer-small-circuit/page.module.css
@@ -24,9 +24,9 @@ div.page {
                 gap: 1em;
                 padding: 1em;
                 border-radius: 99vmax;
-                background-color: #000a;
+                background-color: #0006;
                 box-shadow: 0 0 .25em #fff6;
-                backdrop-filter: blur(8px);
+                backdrop-filter: blur(4px);
 
                 >strong {
                     margin-right: 1em;

--- a/doc/src/app/morpho-viewer-small-circuit/page.tsx
+++ b/doc/src/app/morpho-viewer-small-circuit/page.tsx
@@ -2,10 +2,13 @@ import {
   MorphoViewerSmallCircuit,
   type MorphoViewerSmallCircuitCell,
   type MorphoViewerSmallCircuitCellData,
+  type MorphoViewerSmallCircuitProps,
   morphoViewerConvertMorphologyIntoTree,
 } from "@openbraininstitute/morphoviewer";
 import { ViewSpinner } from "@tolokoban/ui";
 import React from "react";
+
+import { GizmoSettings } from "@/components/gizmo-settings";
 
 import { useCircuit } from "./data";
 
@@ -13,6 +16,7 @@ import styles from "./page.module.css";
 
 export default function Page() {
   const circuit = useCircuit(50);
+  const [gizmo, setGizmo] = React.useState<boolean | MorphoViewerSmallCircuitProps["gizmo"]>(true);
   const [progress, setProgress] = React.useState(0);
   const [selectedCells, setSelectedCells] = React.useState<string[]>([]);
   const [highlightedCellId, setHighlightedCellId] = React.useState("");
@@ -40,6 +44,7 @@ export default function Page() {
           className={styles.viewer}
           backgroundColor="#000"
           circuit={circuit}
+          gizmo={gizmo}
           loadCell={loadCell}
           onCellHover={handleCellHover}
           onCellClick={handleCellClick}
@@ -58,6 +63,7 @@ export default function Page() {
       </div>
       <div>
         <h1>&lt;MorphoViewerSmallCircuit /&gt;</h1>
+        <GizmoSettings value={gizmo} onChange={setGizmo} />
       </div>
     </div>
   );
@@ -67,7 +73,7 @@ async function loadCell(id: string): Promise<MorphoViewerSmallCircuitCellData | 
   try {
     console.log("loadCell:", id);
     const url = `./assets/${id}.json`;
-    const resp = await throttling(fetch(url), 5000);
+    const resp = await throttling(fetch(url), 10000, 5000);
     if (!resp.ok) {
       console.error(`Unable to load ${url}\nError ${resp.status}: ${resp.statusText}`);
     }
@@ -83,9 +89,9 @@ async function loadCell(id: string): Promise<MorphoViewerSmallCircuitCellData | 
   }
 }
 
-async function throttling<T>(promise: Promise<T>, delay: number): Promise<T> {
+async function throttling<T>(promise: Promise<T>, delay: number, min: number): Promise<T> {
   const sleep = new Promise((resolve) => {
-    globalThis.setTimeout(resolve, Math.random() * delay);
+    globalThis.setTimeout(resolve, min + Math.random() * delay);
   });
   const [result] = await Promise.all([promise, sleep]);
   return result;

--- a/doc/src/components/gizmo-settings/gizmo-settings.module.css
+++ b/doc/src/components/gizmo-settings/gizmo-settings.module.css
@@ -1,0 +1,8 @@
+.gizmoSettings {
+    display: flex;
+    flex-wrap: wrap;
+    flex-direction: row;
+    justify-content: flex-start;
+    align-items: center;
+    gap: 1em;
+}

--- a/doc/src/components/gizmo-settings/gizmo-settings.tsx
+++ b/doc/src/components/gizmo-settings/gizmo-settings.tsx
@@ -1,0 +1,74 @@
+import { ViewInputNumber, ViewSlider, ViewSwitch } from "@tolokoban/ui";
+
+import type { MorphoViewerOctreeProps } from "@openbraininstitute/morphoviewer";
+
+import styles from "./gizmo-settings.module.css";
+
+export interface GizmoSettingsProps {
+  value: MorphoViewerOctreeProps["gizmo"];
+  onChange(value: MorphoViewerOctreeProps["gizmo"]): void;
+}
+
+export function GizmoSettings({ value, onChange }: GizmoSettingsProps) {
+  const flag = !!value;
+  const gizmo = resolveGizmo(value ?? false);
+  const update = (
+    partial: Partial<{ alignX: number; alignY: number; size: number; margin: number }>
+  ) => {
+    onChange({
+      ...gizmo,
+      ...partial,
+    });
+  };
+
+  return (
+    <div className={styles.gizmoSettings}>
+      <ViewSwitch
+        value={flag}
+        onChange={(newFlag) => {
+          const newValue = newFlag ? gizmo : false;
+          onChange(newValue);
+        }}
+      >
+        Gizmo
+      </ViewSwitch>
+      {!!value && (
+        <>
+          <ViewInputNumber
+            label="alignX"
+            value={gizmo.alignX}
+            onChange={(alignX) => update({ alignX })}
+          />
+          <ViewInputNumber
+            label="alignY"
+            value={gizmo.alignY}
+            onChange={(alignY) => update({ alignY })}
+          />
+          <ViewInputNumber label="size" value={gizmo.size} onChange={(size) => update({ size })} />
+          <ViewInputNumber
+            label="margin"
+            value={gizmo.margin}
+            onChange={(margin) => update({ margin })}
+          />
+        </>
+      )}
+    </div>
+  );
+}
+
+const DEFAULT_GIZMO_PROPS = {
+  alignX: +1,
+  alignY: -1,
+  size: 128,
+  margin: 8,
+};
+
+function resolveGizmo(
+  value: boolean | { alignX: number; alignY: number; size: number; margin: number }
+): { alignX: number; alignY: number; size: number; margin: number } {
+  if (typeof value === "boolean") return DEFAULT_GIZMO_PROPS;
+  return {
+    ...DEFAULT_GIZMO_PROPS,
+    ...value,
+  };
+}

--- a/doc/src/components/gizmo-settings/index.ts
+++ b/doc/src/components/gizmo-settings/index.ts
@@ -1,0 +1,1 @@
+export * from "./gizmo-settings"

--- a/lib/package-lock.json
+++ b/lib/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@openbraininstitute/morphoviewer",
-    "version": "0.24.19",
+    "version": "0.24.21",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@openbraininstitute/morphoviewer",
-            "version": "0.24.19",
+            "version": "0.24.21",
             "license": "ISC",
             "dependencies": {
                 "@tolokoban/tgd": "^2.0.130",

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@openbraininstitute/morphoviewer",
-    "version": "0.24.20",
+    "version": "0.24.21",
     "description": "Class to display SWC files in 3D on a canvas",
     "main": "./dist/index.js",
     "module": "./dist/index.js",

--- a/lib/src/components/morpho-viewer-octree/painter/manager.ts
+++ b/lib/src/components/morpho-viewer-octree/painter/manager.ts
@@ -33,6 +33,7 @@ const DEFAULT_GIZMO_PROPS: TgdPainterGizmoOptions = {
   size: 128,
   margin: 8,
 };
+
 export class OctreeManager {
   public loadInfo: MorphoViewerOctreeProps["loadInfo"] | null = null;
   public loadBlock: MorphoViewerOctreeProps["loadBlock"] | null = null;
@@ -84,7 +85,6 @@ export class OctreeManager {
     if (this.painterGizmo) {
       const { alignX, alignY, size, margin } =
         this._gizmo === false ? DEFAULT_GIZMO_PROPS : this._gizmo;
-      console.log("🐞 [manager@87] this._gizmo =", this._gizmo); // @FIXME: Remove this line written on 2026-04-29 at 16:53
       this.painterGizmo.alignX = alignX;
       this.painterGizmo.alignY = alignY;
       this.painterGizmo.size = size;
@@ -170,7 +170,6 @@ export class OctreeManager {
     if (!info) return;
 
     const { camera, width, height } = makeCamera(info.bbox);
-    console.log("🐞 [manager@128] camera.near, camera.far =", camera.near, camera.far); // @FIXME: Remove this line written on 2026-03-03 at 15:52
     context.camera = camera;
     this.initialCameraState = {
       width,
@@ -182,11 +181,7 @@ export class OctreeManager {
     this.orbit?.detach();
     this.orbit = new TgdControllerCameraOrbit(context, {
       inertiaOrbit: 1000,
-      // minZoom: 0.1,
-      // maxZoom: 100,
       onZoomRequest: (event) => {
-        console.log("🐞 [manager@142] event.zoom =", event.zoom); // @FIXME: Remove this line written on 2026-03-03 at 15:48
-        console.log("🐞 [manager@143] camera.zoom =", camera.zoom); // @FIXME: Remove this line written on 2026-03-03 at 15:51
         return true;
       },
     });
@@ -215,8 +210,6 @@ export class OctreeManager {
             asset,
             material: this.material,
           });
-          const bbox = mesh.computeBoundingBox();
-          console.log("🐞 [manager@130] bbox =", bbox); // @FIXME: Remove this line written on 2026-03-03 at 11:13
           return mesh;
         }
         return null;

--- a/lib/src/components/morpho-viewer-small-circuit/painter/manager.ts
+++ b/lib/src/components/morpho-viewer-small-circuit/painter/manager.ts
@@ -11,6 +11,8 @@ import {
   TgdPainterClear,
   TgdPainterFilter,
   TgdPainterFramebufferWithAntiAliasing,
+  TgdPainterGizmo,
+  TgdPainterGizmoOptions,
   TgdPainterGroup,
   TgdPainterMix,
   TgdPainterState,
@@ -36,6 +38,14 @@ interface Framebuffer {
   textureColor0?: TgdTexture2D;
   delete(): void;
 }
+
+const DEFAULT_GIZMO_PROPS: TgdPainterGizmoOptions = {
+  alignX: +1,
+  alignY: -1,
+  size: 128,
+  margin: 8,
+};
+
 export class PainterManager {
   public readonly eventRestingPosition = new TgdEvent<boolean>();
   public readonly eventCellHover = new TgdEvent<MorphoViewerSmallCircuitCell | undefined>();
@@ -88,8 +98,38 @@ export class PainterManager {
   private loadedCells = new CacheLRU<Promise<MorphoViewerSmallCircuitCellData | null>>(24);
   private circuitSignature = "";
   private bbox = new TgdBoundingBox();
+  private _gizmo: false | TgdPainterGizmoOptions = false;
+  private painterGizmo: TgdPainterGizmo | null = null;
+  private readonly groupGizmo = new TgdPainterGroup({ name: "GroupGizmo" });
 
   readonly cameraReset = () => this.cameraManager?.resetCamera();
+
+  get gizmo(): false | TgdPainterGizmoOptions {
+    return this._gizmo;
+  }
+  set gizmo(gizmo: boolean | Partial<TgdPainterGizmoOptions> | undefined) {
+    if (this._gizmo === gizmo) return;
+
+    if (gizmo === true) {
+      this._gizmo = DEFAULT_GIZMO_PROPS;
+    } else if (gizmo === false) {
+      this._gizmo = false;
+    } else {
+      this._gizmo = {
+        ...DEFAULT_GIZMO_PROPS,
+        ...gizmo,
+      };
+    }
+    this.groupGizmo.active = !!this._gizmo;
+    if (this.painterGizmo) {
+      const { alignX, alignY, size, margin } =
+        this._gizmo === false ? DEFAULT_GIZMO_PROPS : this._gizmo;
+      this.painterGizmo.alignX = alignX;
+      this.painterGizmo.alignY = alignY;
+      this.painterGizmo.size = size;
+      this.painterGizmo.margin = margin;
+    }
+  }
 
   setCircuit(
     circuit: MorphoViewerSmallCircuitCell[],
@@ -264,7 +304,10 @@ export class PainterManager {
     //     this.createFramebufferBlur(context),
     //     this.createMix(context),
     // )
-
+    this.groupGizmo.removeAll();
+    const painterGizmo = new TgdPainterGizmo(context, DEFAULT_GIZMO_PROPS);
+    this.painterGizmo = painterGizmo;
+    this.groupGizmo.add(painterGizmo);
     context.add(
       clear,
       new TgdPainterState(context, {
@@ -279,7 +322,8 @@ export class PainterManager {
         blend: "add",
         cull: "back",
         children: [this.groupHighlithedCells],
-      })
+      }),
+      this.groupGizmo
     );
     this.updateCircuit();
   }
@@ -428,6 +472,7 @@ export function usePainterManager({
   onCellClick,
   highlightedCellIds,
   onLoadProgress,
+  gizmo,
 }: MorphoViewerSmallCircuitProps) {
   const ref = React.useRef<PainterManager | null>(null);
   if (!ref.current) {
@@ -462,5 +507,9 @@ export function usePainterManager({
       manager.eventCellClick.removeListener(onCellClick);
     };
   }, [onCellClick, manager]);
+  React.useEffect(() => {
+    manager.gizmo = gizmo ?? false;
+  }, [gizmo, manager]);
+
   return ref.current;
 }

--- a/lib/src/components/morpho-viewer-small-circuit/types.ts
+++ b/lib/src/components/morpho-viewer-small-circuit/types.ts
@@ -1,3 +1,5 @@
+import { TgdPainterGizmoOptions } from "@tolokoban/tgd";
+
 import type { MorphoViewerTree } from "../morpho-viewer-simul";
 
 export interface MorphoViewerSmallCircuitCell {
@@ -33,4 +35,15 @@ export interface MorphoViewerSmallCircuitProps {
    * @param progress Percentage of loaded cells so far. Between `0.0` and `1.0`.
    */
   onLoadProgress?(progress: number): void;
+  /**
+   * Display the axes controller gizmo.
+   * - `false`: do not show the Gizmo
+   * - `true`: show it with default options
+   * - `Partial<object>`:
+   *   - `alignX`: -1 meand left and +1 means right
+   *   - `alignY`: -1 meand bottom and +1 means top
+   *   - `size`: size of the Gizmo side in pixels
+   *   - `margin`: margin from the borders of the viewer (in pixels)
+   */
+  gizmo?: boolean | TgdPainterGizmoOptions;
 }

--- a/lib/src/package.json
+++ b/lib/src/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@openbraininstitute/morphoviewer",
-    "version": "0.24.20",
+    "version": "0.24.21",
     "description": "Class to display SWC files in 3D on a canvas",
     "main": "./dist/index.js",
     "module": "./dist/index.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@openbraininstitute/morphoviewer",
-    "version": "0.24.20",
+    "version": "0.24.21",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@openbraininstitute/morphoviewer",
-            "version": "0.24.20",
+            "version": "0.24.21",
             "license": "Apache-2.0",
             "dependencies": {
                 "@tolokoban/tgd": "^2.0.126",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@openbraininstitute/morphoviewer",
-    "version": "0.24.20",
+    "version": "0.24.21",
     "description": "Class to display SWC morphology files in 3D",
     "main": "./lib/dist/index.js",
     "module": "./lib/dist/index.js",

--- a/tst/rspack.config.mjs
+++ b/tst/rspack.config.mjs
@@ -1,6 +1,7 @@
+import * as Rspack from "@rspack/core"
+
 import { execSync } from "node:child_process"
 import Path from "node:path"
-import * as Rspack from "@rspack/core"
 
 const __dirname = Path.dirname(new URL(import.meta.url).pathname)
 


### PR DESCRIPTION
# v0.24.21

- Add optional `gizmo` prop to `MorphoViewerSmallCircuit` for displaying an axes orientation controller
  - Accepts `boolean` or a `Partial<TgdPainterGizmoOptions>` object (`alignX`, `alignY`, `size`, `margin`)
  - Dynamically updates gizmo position, size, and visibility at runtime
- Reuse `GizmoSettings` component in the `MorphoViewerSmallCircuit` doc page for interactive gizmo configuration
- Move `GizmoSettings` component to shared `doc/src/components/gizmo-settings/` directory
- Remove leftover `console.log` debug statements from `OctreeManager`
- Fix import ordering in `tst/rspack.config.mjs`

<img width="511" height="425" alt="image" src="https://github.com/user-attachments/assets/79c34705-1cc6-4aaf-baaa-cd5882941385" />
