### PR TITLE
Update repository metadata pointing to openbraininstitute repo URL

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -30,6 +30,15 @@
     ],
     "author": "Fabien PETITJEAN <fabien.petitjean@epfl.ch>",
     "license": "ISC",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/openbraininstitute/morphoviewer.git",
+        "directory": "lib"
+    },
+    "homepage": "https://openbraininstitute.github.io/morphoviewer/",
+    "bugs": {
+        "url": "https://github.com/openbraininstitute/morphoviewer/issues"
+    },
     "dependencies": {
         "@tolokoban/tgd": "^2.0.130",
         "fflate": "^0.8.2",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     ],
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/BlueBrain/morphoviewer.git"
+        "url": "git+https://github.com/openbraininstitute/morphoviewer.git"
     },
     "keywords": [
         "SWC",


### PR DESCRIPTION
I noticed https://www.npmjs.com/package/@openbraininstitute/morphoviewer points to BlueBrain repo