### PR TITLE
Fix infinite registration of event listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ Copyright (c) 2025 Open Brain Institute
 
 ## Release notes
 
+### v0.25.4
+
+- Fix **event listener leak** in `MorphoViewerSmallCircuit` camera adaptation: the paint event listener was never removed, causing infinite re-registration on each paint cycle
+
 ### v0.25.3
 
 - Add optional `verbose` prop to `MorphoViewerSmallCircuit` for enabling/disabling debug console output

--- a/doc/package.json
+++ b/doc/package.json
@@ -1,6 +1,6 @@
 {
     "name": "extended-swc-viewer",
-    "version": "0.25.3",
+    "version": "0.25.4",
     "private": false,
     "homepage": "./",
     "sideEffects": [

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@openbraininstitute/morphoviewer",
-    "version": "0.25.3",
+    "version": "0.25.4",
     "description": "Class to display SWC files in 3D on a canvas",
     "main": "./dist/index.js",
     "module": "./dist/index.js",

--- a/lib/src/components/morpho-viewer-small-circuit/painter/manager.ts
+++ b/lib/src/components/morpho-viewer-small-circuit/painter/manager.ts
@@ -243,7 +243,7 @@ export class PainterManager {
          * the camera.
          */
         const listener = () => {
-          context.eventPaint.addListener(listener);
+          context.eventPaint.removeListener(listener);
           this.adaptCameraFromBBox();
         };
         context.eventPaint.addListener(listener);

--- a/lib/src/package.json
+++ b/lib/src/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@openbraininstitute/morphoviewer",
-    "version": "0.25.3",
+    "version": "0.25.4",
     "description": "Class to display SWC files in 3D on a canvas",
     "main": "./dist/index.js",
     "module": "./dist/index.js",
@@ -41,7 +41,7 @@
         "url": "https://github.com/openbraininstitute/morphoviewer/issues"
     },
     "dependencies": {
-        "@tolokoban/tgd": "^2.0.136",
+        "@tolokoban/tgd": "^2.0.139",
         "fflate": "^0.8.2",
         "tslib": "^2.8.1"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@openbraininstitute/morphoviewer",
-    "version": "0.25.3",
+    "version": "0.25.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@openbraininstitute/morphoviewer",
-            "version": "0.25.3",
+            "version": "0.25.4",
             "license": "Apache-2.0",
             "dependencies": {
                 "@tolokoban/tgd": "^2.0.139",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@openbraininstitute/morphoviewer",
-    "version": "0.25.3",
+    "version": "0.25.4",
     "description": "Class to display SWC morphology files in 3D",
     "main": "./lib/dist/index.js",
     "module": "./lib/dist/index.js",

--- a/tst/package.json
+++ b/tst/package.json
@@ -1,6 +1,6 @@
 {
     "name": "morphoviewer-tst",
-    "version": "0.25.2",
+    "version": "0.25.4",
     "private": true,
     "scripts": {
         "dev": "rspack serve --mode=development",


### PR DESCRIPTION
### v0.25.4

- Fix **event listener leak** in `MorphoViewerSmallCircuit` camera adaptation: the paint event listener was never removed, causing infinite re-registration on each paint cycle
