### PR TITLE
Maximum stack call

### DIFF
--- a/doc/package.json
+++ b/doc/package.json
@@ -1,6 +1,6 @@
 {
     "name": "extended-swc-viewer",
-    "version": "0.26.4",
+    "version": "0.26.5",
     "private": false,
     "homepage": "./",
     "sideEffects": [

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@openbraininstitute/morphoviewer",
-    "version": "0.26.4",
+    "version": "0.26.5",
     "description": "Class to display SWC files in 3D on a canvas",
     "main": "./dist/index.js",
     "module": "./dist/index.js",

--- a/lib/src/components/morpho-viewer-simul/painter/tree.ts
+++ b/lib/src/components/morpho-viewer-simul/painter/tree.ts
@@ -1,7 +1,6 @@
-import { type ArrayNumber3, TgdVec3 } from "@tolokoban/tgd";
-
 import { MorphoViewerTreeItemType } from "../types/public";
 
+import type { ArrayNumber3 } from "@tolokoban/tgd";
 import type { StructureItem } from "./structure";
 
 export function builTree(items: StructureItem[], soma: StructureItem | null): StructureItem {

--- a/lib/src/components/morpho-viewer-simul/painter/tree.ts
+++ b/lib/src/components/morpho-viewer-simul/painter/tree.ts
@@ -65,15 +65,23 @@ export function populateTree(item: StructureItem, distance = 0) {
 }
 
 export function computeRanks(item: StructureItem, rankMin = -1, rankMax = +1) {
-  if (!item) return;
+  const fringe = [{ item, rankMin, rankMax }];
 
-  item.rank = (rankMin + rankMax) / 2;
-  const rankSize = Math.abs(rankMax - rankMin);
-  let rank = rankMin;
-  for (const child of item.children) {
-    const rankChildSize = (rankSize * child.leavesCount) / item.leavesCount;
-    computeRanks(child, rank, rank + rankChildSize);
-    rank += rankChildSize;
+  while (fringe.length > 0) {
+    const task = fringe.shift();
+    if (!task) return;
+
+    const { item, rankMin, rankMax } = task;
+    if (!item) continue;
+
+    item.rank = (rankMin + rankMax) / 2;
+    const rankSize = Math.abs(rankMax - rankMin);
+    let rank = rankMin;
+    for (const child of item.children) {
+      const rankChildSize = (rankSize * child.leavesCount) / item.leavesCount;
+      fringe.push({ item: child, rankMin: rank, rankMax: rank + rankChildSize });
+      rank += rankChildSize;
+    }
   }
 }
 

--- a/lib/src/components/morpho-viewer-somas-only/manager/manager.ts
+++ b/lib/src/components/morpho-viewer-somas-only/manager/manager.ts
@@ -175,7 +175,7 @@ class PainterManager {
     if (!context) return;
 
     globalThis.clearTimeout(this._cameraChangeTimeout);
-    this._cameraChangeTimeout = globalThis.setTimeout(this.highRes, 50);
+    this._cameraChangeTimeout = globalThis.setTimeout(this.highRes, 50) as unknown as number;
     this.lowRes();
   };
 

--- a/lib/src/package.json
+++ b/lib/src/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@openbraininstitute/morphoviewer",
-    "version": "0.26.4",
+    "version": "0.26.5",
     "description": "Class to display SWC files in 3D on a canvas",
     "main": "./dist/index.js",
     "module": "./dist/index.js",
@@ -42,7 +42,7 @@
         "url": "https://github.com/openbraininstitute/morphoviewer/issues"
     },
     "dependencies": {
-        "@tolokoban/tgd": "^2.0.142",
+        "@tolokoban/tgd": "^2.0.143",
         "fflate": "^0.8.3",
         "tslib": "^2.8.1"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@openbraininstitute/morphoviewer",
-    "version": "0.26.4",
+    "version": "0.26.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@openbraininstitute/morphoviewer",
-            "version": "0.26.4",
+            "version": "0.26.5",
             "license": "Apache-2.0",
             "dependencies": {
                 "@tolokoban/tgd": "^2.0.141",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@openbraininstitute/morphoviewer",
-    "version": "0.26.4",
+    "version": "0.26.5",
     "description": "Class to display SWC morphology files in 3D",
     "main": "./lib/dist/index.js",
     "module": "./lib/dist/index.js",

--- a/tst/package.json
+++ b/tst/package.json
@@ -1,6 +1,6 @@
 {
     "name": "morphoviewer-tst",
-    "version": "0.26.4",
+    "version": "0.26.5",
     "private": true,
     "scripts": {
         "dev": "rspack serve --mode=development",


### PR DESCRIPTION
Google Chrome has a lower tolerance for deep recursivity.
With complex morphologies, we hit the maximum call stack size.

To mitigate this, we have refactored several resursive functions to make them use the heap now.