### PR TITLE
Fix too small synapses from far away

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ Copyright (c) 2025 Open Brain Institute
 
 ## Release notes
 
+### v0.27.2
+
+- Fix **minimum size** for synapses in `MorphoViewerSimul` to prevent them from disappearing at certain zoom levels
+- Simplify **cell highlighting** logic in `MorphoViewerSmallCircuit` by computing black state inline during cell addition
+- Fix the issue with `TGDMaterialFlatTexture` that couldn't change the texture once created.
+
 ### v0.27.1
 
 - PointsClouds were using square with back facing.

--- a/doc/package-lock.json
+++ b/doc/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "extended-swc-viewer",
-    "version": "0.27.0",
+    "version": "0.27.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "extended-swc-viewer",
-            "version": "0.27.0",
+            "version": "0.27.2",
             "dependencies": {
                 "@mdx-js/react": "^3.1.1",
                 "@openbraininstitute/morphoviewer": "file:../lib",
@@ -55,10 +55,10 @@
         },
         "../lib": {
             "name": "@openbraininstitute/morphoviewer",
-            "version": "0.27.0",
+            "version": "0.27.2",
             "license": "ISC",
             "dependencies": {
-                "@tolokoban/tgd": "^2.0.144",
+                "@tolokoban/tgd": "^2.0.147",
                 "fflate": "^0.8.3",
                 "tslib": "^2.8.1"
             },

--- a/doc/package.json
+++ b/doc/package.json
@@ -1,6 +1,6 @@
 {
     "name": "extended-swc-viewer",
-    "version": "0.27.1",
+    "version": "0.27.2",
     "private": false,
     "homepage": "./",
     "sideEffects": [

--- a/lib/package-lock.json
+++ b/lib/package-lock.json
@@ -1,16 +1,16 @@
 {
     "name": "@openbraininstitute/morphoviewer",
-    "version": "0.26.3",
+    "version": "0.27.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@openbraininstitute/morphoviewer",
-            "version": "0.26.3",
+            "version": "0.27.1",
             "license": "ISC",
             "dependencies": {
-                "@tolokoban/tgd": "^2.0.141",
-                "fflate": "^0.8.2",
+                "@tolokoban/tgd": "^2.0.145",
+                "fflate": "^0.8.3",
                 "tslib": "^2.8.1"
             },
             "devDependencies": {
@@ -36,7 +36,7 @@
         },
         "../../../github/game/tgd2": {
             "name": "@tolokoban/tgd",
-            "version": "2.0.142",
+            "version": "2.0.146",
             "license": "GPL-3.0",
             "dependencies": {
                 "@loaders.gl/core": "^4.3.4",
@@ -45,13 +45,12 @@
                 "gl-matrix": "^3.4.4"
             },
             "devDependencies": {
-                "@biomejs/biome": "^2.4.15",
+                "@biomejs/biome": "^2.4.16",
                 "@types/node": "^25.6.0",
-                "biome": "^0.3.3",
                 "http-server": "^14.1.1",
                 "lefthook": "^1.13.0",
-                "oxfmt": "^0.36.0",
-                "oxlint": "^1.51.0",
+                "oxfmt": "^0.54.0",
+                "oxlint": "^1.69.0",
                 "prettier": "^3.6.2",
                 "typescript": "^5.9.2"
             }
@@ -3406,9 +3405,9 @@
             }
         },
         "node_modules/fflate": {
-            "version": "0.8.2",
-            "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
-            "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+            "version": "0.8.3",
+            "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+            "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
             "license": "MIT"
         },
         "node_modules/fill-range": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@openbraininstitute/morphoviewer",
-    "version": "0.27.1",
+    "version": "0.27.2",
     "description": "Class to display SWC files in 3D on a canvas",
     "main": "./dist/index.js",
     "module": "./dist/index.js",
@@ -42,7 +42,7 @@
         "url": "https://github.com/openbraininstitute/morphoviewer/issues"
     },
     "dependencies": {
-        "@tolokoban/tgd": "^2.0.145",
+        "@tolokoban/tgd": "^2.0.147",
         "fflate": "^0.8.3",
         "tslib": "^2.8.1"
     },

--- a/lib/pnpm-lock.yaml
+++ b/lib/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@tolokoban/tgd':
-        specifier: ^2.0.145
-        version: 2.0.145
+        specifier: ^2.0.147
+        version: 2.0.147
       fflate:
         specifier: ^0.8.3
         version: 0.8.3
@@ -569,8 +569,8 @@ packages:
   '@swc/helpers@0.5.23':
     resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
 
-  '@tolokoban/tgd@2.0.145':
-    resolution: {integrity: sha512-sYzp0fl+k7itgAIw33gzP0D3lrouw5mEReJNTA8Y1faIidz4gWaKwh3uCwTvL/BBJmItVdYgZP+R2eiYZxZP/w==}
+  '@tolokoban/tgd@2.0.147':
+    resolution: {integrity: sha512-gK47cNFtFVl2dbl3jQ9wkw6DtrQbypbVLZmgGzHN6S0oy8Y7Xl5UlPIVHOIM+oVK4Zp/x98U4OhNpOEBpNDlIQ==}
 
   '@ts-morph/common@0.28.1':
     resolution: {integrity: sha512-W74iWf7ILp1ZKNYXY5qbddNaml7e9Sedv5lvU1V8lftlitkc9Pq1A+jlH23ltDgWYeZFFEqGCD1Ies9hqu3O+g==}
@@ -2996,7 +2996,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@tolokoban/tgd@2.0.145':
+  '@tolokoban/tgd@2.0.147':
     dependencies:
       '@loaders.gl/core': 4.4.2
       '@loaders.gl/draco': 4.4.2(@loaders.gl/core@4.4.2)

--- a/lib/src/components/morpho-viewer-simul/painter/painters/synapses.ts
+++ b/lib/src/components/morpho-viewer-simul/painter/painters/synapses.ts
@@ -35,7 +35,7 @@ export class PainterSynapses extends TgdPainterGroup {
       name: `TgdPainterPointsCloud[${synapses.color}]`,
       mix: 0,
       data: [[dataPoint3D, dataPointDendrogram]],
-      //   minSizeInPixels: 4,
+      minSizeInPixels: 0.007,
       radiusMultiplier: 0.5,
       texture,
       fragCode: TgdPainterPointsCloudMorphing.fragCodeSphere({

--- a/lib/src/components/morpho-viewer-small-circuit/painter/manager.ts
+++ b/lib/src/components/morpho-viewer-small-circuit/painter/manager.ts
@@ -260,14 +260,9 @@ export class PainterManager {
     for (const cell of circuit) {
       const painter = cellsForHighights.get(cell.id);
       if (painter) {
-        painter.black = true;
+        painter.black = !(highlightedCellIds ?? []).includes(cell.id);
+        console.log("Added highlighted cell:", cell, painter.black);
         groupHighlithedCells.add(painter);
-      }
-    }
-    for (const id of highlightedCellIds ?? []) {
-      const painter = cellsForHighights.get(id);
-      if (painter) {
-        painter.black = false;
       }
     }
     this.context.value?.paint();

--- a/lib/src/components/morpho-viewer-small-circuit/painter/manager.ts
+++ b/lib/src/components/morpho-viewer-small-circuit/painter/manager.ts
@@ -261,7 +261,6 @@ export class PainterManager {
       const painter = cellsForHighights.get(cell.id);
       if (painter) {
         painter.black = !(highlightedCellIds ?? []).includes(cell.id);
-        console.log("Added highlighted cell:", cell, painter.black);
         groupHighlithedCells.add(painter);
       }
     }

--- a/lib/src/components/morpho-viewer-somas-only/manager/manager.ts
+++ b/lib/src/components/morpho-viewer-somas-only/manager/manager.ts
@@ -15,7 +15,7 @@ import React from "react";
 import { watchSpacePerPixel } from "@/behaviors";
 import { PainterGizmo } from "@/painters/gizmo";
 
-import { AdpatativeResolution } from "./adaptative-resolution";
+import { AdpatativeResolution, AdpatativeResolution } from "./adaptative-resolution";
 import { PainterCellInfos } from "./painter-cell-infos";
 
 import type { MorphoViewerCellInfo, MorphoViewerSomasOnlyProps } from "../types";
@@ -35,6 +35,7 @@ class PainterManager {
   private scalebarCleanup: (() => void) | null = null;
   private readonly painterGizmo = new PainterGizmo();
   private readonly adaptativeResolution = new AdpatativeResolution();
+  private readonly adaptativeResolution = new AdpatativeResolution();
   private _somaRadius = 1;
   private readonly cameraOrtho = new TgdCameraOrthographic({ name: "CameraOrtho" });
   private readonly cameraPersp = new TgdCameraPerspective({ name: "CameraPersp" });
@@ -49,7 +50,6 @@ class PainterManager {
     this._cameraType = cameraType;
     const { context } = this;
     if (context) {
-      console.log("🐞 [manager@52] cameraType =", cameraType); // @FIXME: Remove this line written on 2026-06-16 at 12:23
       context.camera = cameraType === "orthographic" ? this.cameraOrtho : this.cameraPersp;
       this.applyBBoxToCamera();
       context.paint();

--- a/lib/src/components/morpho-viewer-somas-only/manager/manager.ts
+++ b/lib/src/components/morpho-viewer-somas-only/manager/manager.ts
@@ -15,7 +15,7 @@ import React from "react";
 import { watchSpacePerPixel } from "@/behaviors";
 import { PainterGizmo } from "@/painters/gizmo";
 
-import { AdpatativeResolution, AdpatativeResolution } from "./adaptative-resolution";
+import { AdpatativeResolution } from "./adaptative-resolution";
 import { PainterCellInfos } from "./painter-cell-infos";
 
 import type { MorphoViewerCellInfo, MorphoViewerSomasOnlyProps } from "../types";
@@ -34,7 +34,6 @@ class PainterManager {
   private bbox = new TgdBoundingBox();
   private scalebarCleanup: (() => void) | null = null;
   private readonly painterGizmo = new PainterGizmo();
-  private readonly adaptativeResolution = new AdpatativeResolution();
   private readonly adaptativeResolution = new AdpatativeResolution();
   private _somaRadius = 1;
   private readonly cameraOrtho = new TgdCameraOrthographic({ name: "CameraOrtho" });

--- a/lib/src/package.json
+++ b/lib/src/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@openbraininstitute/morphoviewer",
-    "version": "0.27.1",
+    "version": "0.27.2",
     "description": "Class to display SWC files in 3D on a canvas",
     "main": "./dist/index.js",
     "module": "./dist/index.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@openbraininstitute/morphoviewer",
-    "version": "0.27.1",
+    "version": "0.27.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@openbraininstitute/morphoviewer",
-            "version": "0.27.1",
+            "version": "0.27.2",
             "license": "Apache-2.0",
             "dependencies": {
                 "@tolokoban/tgd": "^2.0.141",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@openbraininstitute/morphoviewer",
-    "version": "0.27.1",
+    "version": "0.27.2",
     "description": "Class to display SWC morphology files in 3D",
     "main": "./lib/dist/index.js",
     "module": "./lib/dist/index.js",
@@ -39,7 +39,7 @@
         "react": "^19.2.4"
     },
     "dependencies": {
-        "@tolokoban/tgd": "^2.0.145",
+        "@tolokoban/tgd": "^2.0.147",
         "fflate": "^0.8.2",
         "tslib": "^2.8.1"
     },

--- a/tst/package.json
+++ b/tst/package.json
@@ -1,6 +1,6 @@
 {
     "name": "morphoviewer-tst",
-    "version": "0.27.1",
+    "version": "0.27.2",
     "private": true,
     "scripts": {
         "dev": "rspack serve --mode=development",

--- a/tst/pnpm-lock.yaml
+++ b/tst/pnpm-lock.yaml
@@ -460,6 +460,9 @@ packages:
   '@tolokoban/tgd@2.0.141':
     resolution: {integrity: sha512-M1k2leWnvfZ7hQWxxy2Qz9bHCvOhXy4bnmCuFPyOGoLCYZnQxOUJRcCmsuIQHw18W5vgoDDfTpR+QfCvf8OQVQ==}
 
+  '@tolokoban/tgd@2.0.147':
+    resolution: {integrity: sha512-gK47cNFtFVl2dbl3jQ9wkw6DtrQbypbVLZmgGzHN6S0oy8Y7Xl5UlPIVHOIM+oVK4Zp/x98U4OhNpOEBpNDlIQ==}
+
   '@tolokoban/type-guards@0.9.0':
     resolution: {integrity: sha512-MLOlLsGBrvol1yR25K/kai7/DoZtVYHmedRxKmjS8We7vwwas/9wyVvijAg0bcAucOSNOyWtviNikLkmvri9lQ==}
 
@@ -2401,7 +2404,7 @@ snapshots:
 
   '@openbraininstitute/morphoviewer@file:..(react@19.2.7)':
     dependencies:
-      '@tolokoban/tgd': 2.0.141
+      '@tolokoban/tgd': 2.0.147
       fflate: 0.8.3
       react: 19.2.7
       tslib: 2.8.1
@@ -2562,6 +2565,15 @@ snapshots:
       '@tauri-apps/cli-win32-x64-msvc': 2.11.2
 
   '@tolokoban/tgd@2.0.141':
+    dependencies:
+      '@loaders.gl/core': 4.4.2
+      '@loaders.gl/draco': 4.4.2(@loaders.gl/core@4.4.2)
+      '@loaders.gl/gltf': 4.4.2(@loaders.gl/core@4.4.2)
+      gl-matrix: 3.4.4
+    transitivePeerDependencies:
+      - '@75lb/nature'
+
+  '@tolokoban/tgd@2.0.147':
     dependencies:
       '@loaders.gl/core': 4.4.2
       '@loaders.gl/draco': 4.4.2(@loaders.gl/core@4.4.2)


### PR DESCRIPTION
### v0.27.2

- Fix **minimum size** for synapses in `MorphoViewerSimul` to prevent them from disappearing at certain zoom levels
- Simplify **cell highlighting** logic in `MorphoViewerSmallCircuit` by computing black state inline during cell addition
- Fix the issue with `TGDMaterialFlatTexture` that couldn't change the texture once created.
