### PR TITLE
Add synapses for small circuits

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ Copyright (c) 2025 Open Brain Institute
 
 ## Release notes
 
+### v0.29.0
+
+- Add **version tracking** via `data-version` attribute on root elements of `MorphoViewerOctree`, `MorphoViewerSimul`, `MorphoViewerSmallCircuit`, and `MorphoViewerSomasOnly`
+- Add **synapses** support to `MorphoViewerSmallCircuit`
+  - New `synapses`, `synapsesRadius`, and `synapsesMinRadiusInPixels` props
+  - Dynamically updates synapse rendering without recreating the painter
+
 ### v0.27.2
 
 - Fix **minimum size** for synapses in `MorphoViewerSimul` to prevent them from disappearing at certain zoom levels

--- a/doc/package.json
+++ b/doc/package.json
@@ -1,6 +1,6 @@
 {
     "name": "extended-swc-viewer",
-    "version": "0.28.0",
+    "version": "0.29.0",
     "private": false,
     "homepage": "./",
     "sideEffects": [

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@openbraininstitute/morphoviewer",
-    "version": "0.28.0",
+    "version": "0.29.0",
     "description": "Class to display SWC files in 3D on a canvas",
     "main": "./dist/index.js",
     "module": "./dist/index.js",

--- a/lib/src/components/morpho-viewer-octree/morpho-viewer-octree.tsx
+++ b/lib/src/components/morpho-viewer-octree/morpho-viewer-octree.tsx
@@ -1,6 +1,7 @@
 import { tgdFullscreenToggle } from "@tolokoban/tgd";
 import React from "react";
 
+import { version } from "@/index";
 import { classNames } from "@/utils";
 
 import { MorphoViewerIconCenter } from "../icons/center";
@@ -26,7 +27,11 @@ export function MorphoViewerOctree(props: MorphoViewerOctreeProps) {
   };
 
   return (
-    <div className={classNames(props.className, styles.morphoViewerOctree)} ref={ref}>
+    <div
+      className={classNames(props.className, styles.morphoViewerOctree)}
+      ref={ref}
+      data-version={version}
+    >
       <Canvas painterManager={manager} />
       <header>
         <button type="button" onClick={handleResetCamera}>

--- a/lib/src/components/morpho-viewer-simul/morpho-viewer-simul.tsx
+++ b/lib/src/components/morpho-viewer-simul/morpho-viewer-simul.tsx
@@ -1,6 +1,7 @@
 import { tgdFullscreenToggle } from "@tolokoban/tgd";
 import React from "react";
 
+import { version } from "@/index";
 import { useDebugMode } from "@/utils";
 
 import { ButtonCameraReset } from "../button-reset-camera";
@@ -40,7 +41,7 @@ export function MorphoViewerSimul(props: MorphoViewerSimulProps) {
   };
 
   return (
-    <div className={styles.main} ref={ref}>
+    <div className={styles.main} ref={ref} data-version={version}>
       <Canvas painterManager={painterManager} />
       <HintPanel painterManager={painterManager} />
       <header>

--- a/lib/src/components/morpho-viewer-small-circuit/morpho-viewer-small-circuit.tsx
+++ b/lib/src/components/morpho-viewer-small-circuit/morpho-viewer-small-circuit.tsx
@@ -1,6 +1,7 @@
 import { tgdFullscreenToggle } from "@tolokoban/tgd";
 import React from "react";
 
+import { version } from "@/index";
 import { classNames } from "@/utils";
 
 import { type ControlAction, ControlsLayout } from "../controls-layout";
@@ -81,6 +82,7 @@ export function MorphoViewerSmallCircuit(props: MorphoViewerSmallCircuitProps) {
       style={{
         background: props.backgroundColor ?? "#000",
       }}
+      data-version={version}
     >
       <Canvas painterManager={manager} />
       <ControlsLayout

--- a/lib/src/components/morpho-viewer-small-circuit/painter/manager.ts
+++ b/lib/src/components/morpho-viewer-small-circuit/painter/manager.ts
@@ -23,6 +23,7 @@ import { CacheLRU } from "@/tools/cache-lru";
 import { CameraManager } from "./camera";
 import { OffscreenPainter } from "./offscreen-painter";
 import { PainterCell } from "./painter-cell";
+import { PainterSynapses } from "./painter-synapses";
 
 import type {
   MorphoViewerSmallCircuitCell,
@@ -91,6 +92,7 @@ export class PainterManager {
   private bbox = new TgdBoundingBox();
   private _verbose = false;
   private readonly painterGizmo = new PainterGizmo();
+  private painterSynapses: PainterSynapses | null = null;
 
   get gizmo() {
     return this.painterGizmo.options;
@@ -304,6 +306,8 @@ export class PainterManager {
       verbose: this.verbose,
       name: "RenderingContext",
     });
+    const painterSynapses = new PainterSynapses(context);
+    this.painterSynapses = painterSynapses;
     this.context.value = context;
     context.camera = new TgdCameraOrthographic({
       zoom: 1,
@@ -329,7 +333,7 @@ export class PainterManager {
       new TgdPainterState(context, {
         depth: "less",
         cull: "back",
-        children: [this.groupCells],
+        children: [this.groupCells, painterSynapses],
       }),
       // Highlighted cells
       new TgdPainterClear(context, { name: "Clear depth", depth: 1 }),

--- a/lib/src/components/morpho-viewer-small-circuit/painter/manager.ts
+++ b/lib/src/components/morpho-viewer-small-circuit/painter/manager.ts
@@ -7,7 +7,6 @@ import {
   type TgdInputPointerEventMove,
   type TgdInputPointerEventTap,
   TgdPainterClear,
-  TgdPainterGizmo,
   type TgdPainterGizmoOptions,
   TgdPainterGroup,
   TgdPainterState,
@@ -111,6 +110,19 @@ export class PainterManager {
 
     this._verbose = verbose;
     if (this.context.value) this.context.value.verbose = verbose;
+  }
+
+  setSynapses(
+    synapses: { color: string; coordinates: Float32Array | number[] }[] | undefined,
+    synapsesRadius: number,
+    synapsesMinRadiusInPixels: number
+  ) {
+    const { painterSynapses } = this;
+    if (!painterSynapses) return;
+
+    painterSynapses.synapses = synapses ?? [];
+    painterSynapses.radius = synapsesRadius;
+    painterSynapses.minRadiusInPixels = synapsesMinRadiusInPixels;
   }
 
   setCircuit(
@@ -423,6 +435,9 @@ export function usePainterManager({
   onLoadProgress,
   gizmo,
   verbose,
+  synapses,
+  synapsesRadius = 5,
+  synapsesMinRadiusInPixels = 4,
 }: MorphoViewerSmallCircuitProps) {
   const [, setSpacePerPixel] = React.useState(-1);
   const ref = React.useRef<PainterManager | null>(null);
@@ -443,6 +458,9 @@ export function usePainterManager({
   React.useEffect(() => {
     manager.highlightedCellIds = highlightedCellIds;
   }, [highlightedCellIds, manager]);
+  React.useEffect(() => {
+    manager.setSynapses(synapses, synapsesRadius, synapsesMinRadiusInPixels);
+  }, [synapses, synapsesRadius, synapsesMinRadiusInPixels, manager]);
   React.useEffect(() => {
     if (!onCellHover) return;
 

--- a/lib/src/components/morpho-viewer-small-circuit/painter/painter-synapses/index.ts
+++ b/lib/src/components/morpho-viewer-small-circuit/painter/painter-synapses/index.ts
@@ -1,0 +1,1 @@
+export * from "./painter-synapses"

--- a/lib/src/components/morpho-viewer-small-circuit/painter/painter-synapses/painter-synapses.ts
+++ b/lib/src/components/morpho-viewer-small-circuit/painter/painter-synapses/painter-synapses.ts
@@ -1,0 +1,89 @@
+import {
+  TgdContext,
+  TgdPainterGroup,
+  TgdPainterPointsCloud,
+  TgdTexture2D,
+  tgdCanvasCreatePalette,
+} from "@tolokoban/tgd";
+
+export class PainterSynapses extends TgdPainterGroup {
+  private readonly texture: TgdTexture2D;
+  private _synapses: Array<{ coordinates: number[] | Float32Array; color: string }> = [];
+  private painter: TgdPainterPointsCloud | null = null;
+  private _radius = 5;
+  private _minRadiusInPixels = 4;
+
+  constructor(public readonly context: TgdContext) {
+    super({ name: "PainterSynapses" });
+    this.texture = new TgdTexture2D(context, {
+      params: {
+        magFilter: "NEAREST",
+        minFilter: "NEAREST",
+      },
+    });
+  }
+
+  get radius(): number {
+    return this._radius;
+  }
+  set radius(radius: number) {
+    if (this._radius === radius) return;
+
+    this._radius = radius;
+    const { painter } = this;
+    if (painter) {
+      painter.radiusMultiplier = radius;
+      this.context.paint();
+    }
+  }
+
+  get minRadiusInPixels(): number {
+    return this._minRadiusInPixels;
+  }
+  set minRadiusInPixels(minRadiusInPixels: number) {
+    if (this._minRadiusInPixels === minRadiusInPixels) return;
+
+    this._minRadiusInPixels = minRadiusInPixels;
+    const { painter } = this;
+    if (painter) {
+      painter.minSizeInPixels = minRadiusInPixels;
+      this.context.paint();
+    }
+  }
+
+  get synapses(): Array<{ coordinates: number[] | Float32Array; color: string }> {
+    return this._synapses;
+  }
+  set synapses(synapses: Array<{ coordinates: number[] | Float32Array; color: string }>) {
+    if (this._synapses === synapses) return;
+
+    this._synapses = synapses;
+    this.removeAll();
+    if (synapses.length > 0) {
+      this.texture.loadBitmap(tgdCanvasCreatePalette(synapses.map((synapse) => synapse.color)));
+      const attXYZR: number[] = [];
+      const attUV: number[] = [];
+      for (let indexGroup = 0; indexGroup < synapses.length; indexGroup++) {
+        const group = synapses[indexGroup];
+        const u = (indexGroup + 0.5) / synapses.length;
+        for (let indexCoords = 0; indexCoords < group.coordinates.length; indexCoords += 3) {
+          const x = group.coordinates[indexCoords + 0];
+          const y = group.coordinates[indexCoords + 1];
+          const z = group.coordinates[indexCoords + 2];
+          attXYZR.push(x, y, z, 1);
+          attUV.push(u, 0.5);
+        }
+      }
+      const painter = new TgdPainterPointsCloud(this.context, {
+        dataPoint: new Float32Array(attXYZR),
+        dataUV: new Float32Array(attUV),
+        texture: this.texture,
+        radiusMultiplier: this.radius,
+        minSizeInPixels: this.minRadiusInPixels,
+      });
+      this.painter = painter;
+      this.add(painter);
+    }
+    this.context.paint();
+  }
+}

--- a/lib/src/components/morpho-viewer-small-circuit/painter/painter-synapses/painter-synapses.ts
+++ b/lib/src/components/morpho-viewer-small-circuit/painter/painter-synapses/painter-synapses.ts
@@ -1,5 +1,5 @@
 import {
-  TgdContext,
+  type TgdContext,
   TgdPainterGroup,
   TgdPainterPointsCloud,
   TgdTexture2D,

--- a/lib/src/components/morpho-viewer-small-circuit/types.ts
+++ b/lib/src/components/morpho-viewer-small-circuit/types.ts
@@ -29,6 +29,12 @@ export type MorphoViewerSmallCircuitProps = PropsForGizmo &
     className?: string;
     backgroundColor?: string;
     circuit: MorphoViewerSmallCircuitCell[];
+    synapses?: Array<{
+      color: string;
+      coordinates: Float32Array | number[];
+    }>;
+    synapsesRadius?: number;
+    synapsesMinRadiusInPixels?: number;
     /**
      * Ids of the cells we want to highlight.
      */

--- a/lib/src/components/morpho-viewer-somas-only/morpho-viewer-somas-only.tsx
+++ b/lib/src/components/morpho-viewer-somas-only/morpho-viewer-somas-only.tsx
@@ -1,6 +1,7 @@
 import { tgdFullscreenToggle } from "@tolokoban/tgd";
 import React from "react";
 
+import { version } from "@/index";
 import { classNames } from "@/utils";
 
 import { type ControlAction, ControlsLayout } from "../controls-layout";
@@ -38,7 +39,11 @@ export function MorphoViewerSomasOnly(props: MorphoViewerSomasOnlyProps) {
   };
 
   return (
-    <div ref={ref} className={classNames(props.className, styles.morphoViewerSomasOnly)}>
+    <div
+      ref={ref}
+      className={classNames(props.className, styles.morphoViewerSomasOnly)}
+      data-version={version}
+    >
       <Canvas painterManager={painterManager} />
       <ControlsLayout
         content={props.controls ?? getDefaultControls(props)}

--- a/lib/src/package.json
+++ b/lib/src/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@openbraininstitute/morphoviewer",
-    "version": "0.28.0",
+    "version": "0.29.0",
     "description": "Class to display SWC files in 3D on a canvas",
     "main": "./dist/index.js",
     "module": "./dist/index.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@openbraininstitute/morphoviewer",
-    "version": "0.28.0",
+    "version": "0.29.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@openbraininstitute/morphoviewer",
-            "version": "0.28.0",
+            "version": "0.29.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@tolokoban/tgd": "^2.0.141",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@openbraininstitute/morphoviewer",
-    "version": "0.28.0",
+    "version": "0.29.0",
     "description": "Class to display SWC morphology files in 3D",
     "main": "./lib/dist/index.js",
     "module": "./lib/dist/index.js",

--- a/tst/package.json
+++ b/tst/package.json
@@ -1,6 +1,6 @@
 {
     "name": "morphoviewer-tst",
-    "version": "0.28.0",
+    "version": "0.29.0",
     "private": true,
     "scripts": {
         "dev": "rspack serve --mode=development",


### PR DESCRIPTION
Relates to this ticket: https://github.com/openbraininstitute/prod-singlecell-simulation/issues/274

### v0.29.0

- Add **version tracking** via `data-version` attribute on root elements of `MorphoViewerOctree`, `MorphoViewerSimul`, `MorphoViewerSmallCircuit`, and `MorphoViewerSomasOnly`
- Add **synapses** support to `MorphoViewerSmallCircuit`
  - New `synapses`, `synapsesRadius`, and `synapsesMinRadiusInPixels` props
  - Dynamically updates synapse rendering without recreating the painter

<img width="827" height="516" alt="image" src="https://github.com/user-attachments/assets/8b774ae7-5d2d-4022-951d-8a354011164f" />
